### PR TITLE
Edit DOUBLE_TAP binding name

### DIFF
--- a/Assets/MyoPlugin/Scripts/MyoBinding.cs
+++ b/Assets/MyoPlugin/Scripts/MyoBinding.cs
@@ -13,7 +13,7 @@ namespace MyoUnity
 		WAVE_IN = 2,
 		WAVE_OUT = 3,
 		FINGERS_SPREAD = 4,
-		DOUBLE_TAB = 5
+		DOUBLE_TAP = 5
 	};
 
 	public enum MyoVibrateLength


### PR DESCRIPTION
Changed DOUBLE_TAB to DOUBLE_TAP in order to match the myo plugin notation.
Fix #4 